### PR TITLE
[fix] Fix bug of gpt-5. Update default api_key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-error.log*
 
 # configs/.env
 configs/oai_config.py
+!configs/.env
 
 # Cache
 _del/

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ yarn-error.log*
 .env.*
 *.pem
 
-configs/.env
+# configs/.env
 configs/oai_config.py
 
 # Cache

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ coverage/
 # Temporary files
 tmp/
 temp/
+.temp
 
 # Python
 __pycache__/

--- a/configs/.env
+++ b/configs/.env
@@ -1,0 +1,43 @@
+# ==============================================================================
+# RepoMaster Environment Configuration Example
+# ==============================================================================
+# Copy this file to .env and fill in your actual API keys and configurations
+
+# ==============================================================================
+# Default API Provider Configuration
+# ==============================================================================
+# Set the default API provider (openai, claude, deepseek, azure_openai)
+# If not set, will use the first available provider in priority order
+DEFAULT_API_PROVIDER=openai
+
+# ==============================================================================
+# Search Engine APIs
+# Get your API key at: https://serper.dev/login
+SERPER_API_KEY=${SERPER_API_KEY}
+
+# Jina AI (for document processing)
+# Get your API key at: https://jina.ai/
+JINA_API_KEY=${JINA_API_KEY}
+
+
+# ==============================================================================
+# LLM Provider API Keys
+# ==============================================================================
+
+# OpenAI Configuration
+OPENAI_API_KEY=${OPENAI_API_KEY}
+OPENAI_MODEL=gpt-5
+OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Anthropic Claude Configuration
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+ANTHROPIC_MODEL=claude-4-sonnet
+
+# DeepSeek Configuration
+DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
+DEEPSEEK_MODEL=deepseek-v3
+DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+
+# Google Gemini Configuration
+GEMINI_API_KEY=${GEMINI_API_KEY}
+GEMINI_MODEL=gemini-2.5-pro

--- a/configs/mode_config.py
+++ b/configs/mode_config.py
@@ -322,6 +322,21 @@ def print_config_info(config: RunConfig):
     from src.frontend.terminal_show import print_launch_config
     print_launch_config(config)
 
+
+def verify_config(
+    config_manager: ModeConfigManager, 
+    config_info: list,
+    model: str
+    ):
+    """Verify if the configuration manager's config meets the required config_info"""
+    if model in ['gpt-5']:
+        if config_manager.config.temperature != 1.0:
+            print(f"⚠️  Warning: {model} only support temperature=1.0. Resetting...")
+            config_manager.config.temperature = 1.0
+
+    return config_manager
+
+
 if __name__ == "__main__":
     # Example usage
     parser = create_argument_parser()

--- a/launcher.py
+++ b/launcher.py
@@ -28,7 +28,10 @@ import subprocess
 from pathlib import Path
 
 
-from configs.mode_config import ModeConfigManager, create_argument_parser, print_config_info
+from configs.mode_config import (
+    ModeConfigManager, create_argument_parser, print_config_info,
+    verify_config
+)
 from src.frontend.terminal_show import (
     print_repomaster_cli, print_startup_banner, print_environment_status, 
     print_api_config_status, print_launch_config, print_service_starting,
@@ -558,6 +561,10 @@ def main():
         
         # Create configuration manager
         config_manager = ModeConfigManager.from_args(args)
+
+        # Verify config_manager.config can meet config_info
+        config_manager = verify_config(config_manager, config_info=config_info, model=model)
+         
         
         # Print optimized startup sequence  
         print_progressive_startup_panel(env_status, api_status, config_manager.config)

--- a/temp
+++ b/temp
@@ -1,0 +1,7 @@
+[fix] Fix bug of gpt-5. Update default api_key.
+
+
+1. gpt-5 only supports `temperature=1`. I fix this bug by add the `configs/model_config.py::verify_config` function, which can also be extended in future dev.
+2. I set the api key value to point to system's default values in `.env`. Users may not need to reconfigure again.
+
+

--- a/temp
+++ b/temp
@@ -1,7 +1,0 @@
-[fix] Fix bug of gpt-5. Update default api_key.
-
-
-1. gpt-5 only supports `temperature=1`. I fix this bug by add the `configs/model_config.py::verify_config` function, which can also be extended in future dev.
-2. I set the api key value to point to system's default values in `.env`. Users may not need to reconfigure again.
-
-


### PR DESCRIPTION
1. gpt-5 only supports `temperature=1`. I fix this bug by add the `configs/model_config.py::verify_config` function, which can also be extended in future dev
2. I set the api key value to point to system's default values in `.env`. So users may not need to reconfigure again, if they already configure those values (e.g. in `.bashrc`)


The error raised by using gpt-5 with `temperature=1`
```
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/sijie/miniconda3/envs/repo/lib/python3.10/site-packages/openai/_base_client.py", line 919, in request
    return self._request(
  File "/home/sijie/miniconda3/envs/repo/lib/python3.10/site-packages/openai/_base_client.py", line 1023, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': "Unsupported value: 'temperature' does not support 0.1 with this model. Only the default (1) value is supported.", 'type': 'invalid_request_error', 'param': 'temperature', 'code': 'unsupported_value'}}


❌ Task execution error: Error code: 400 - {'error': {'message': "Unsupported value: 'temperature' does not support 0.1 with this model. Only the default (1) value is supported.", 'type': 'invalid_request_error', 'param': 'temperature', 'code': 'unsupported_value'}}
   💡 Please try to describe your task requirements in more detail
```