### PR TITLE
[fix] Fix bug of gpt-5. Update default api_key.

### DIFF
--- a/configs/env.example
+++ b/configs/env.example
@@ -13,11 +13,11 @@ DEFAULT_API_PROVIDER=openai
 # ==============================================================================
 # Search Engine APIs
 # Get your API key at: https://serper.dev/login
-SERPER_API_KEY=
+SERPER_API_KEY=${SERPER_API_KEY}
 
 # Jina AI (for document processing)
 # Get your API key at: https://jina.ai/
-JINA_API_KEY=
+JINA_API_KEY=${JINA_API_KEY}
 
 
 # ==============================================================================
@@ -25,19 +25,19 @@ JINA_API_KEY=
 # ==============================================================================
 
 # OpenAI Configuration
-OPENAI_API_KEY=
+OPENAI_API_KEY=${OPENAI_API_KEY}
 OPENAI_MODEL=gpt-5
 OPENAI_BASE_URL=https://api.openai.com/v1
 
 # Anthropic Claude Configuration
-ANTHROPIC_API_KEY=your_anthropic_api_key_here
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
 ANTHROPIC_MODEL=claude-4-sonnet
 
 # DeepSeek Configuration
-DEEPSEEK_API_KEY=
+DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
 DEEPSEEK_MODEL=deepseek-v3
 DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
 
 # Google Gemini Configuration
-GEMINI_API_KEY=
+GEMINI_API_KEY=${GEMINI_API_KEY}
 GEMINI_MODEL=gemini-2.5-pro

--- a/configs/oai_config.py
+++ b/configs/oai_config.py
@@ -196,6 +196,15 @@ def get_llm_config(api_type: str = None, timeout: int = 240, temperature: float 
     api_config["temperature"] = temperature
     api_config["top_p"] = top_p
     
+    # Verify config
+    model = api_config.get('config_list', [{}])[0].get('model', 'N/A')
+    if api_type in ['basic', 'openai']:
+        if model in ['gpt-5']:
+            api_config.pop("top_p") # gpt-5 does not support top_p
+            if api_config["temperature"] != 1.0:
+                warnings.warn(f"⚠️  Model '{model}' only support temperature=1.0. Resetting...")
+                api_config["temperature"] = 1.0
+                
     return api_config
 
 def load_envs_func():


### PR DESCRIPTION

1. gpt-5 only supports `temperature=1` and does not support `top_p`. I fix this bug in `configs/oai_config.py`, which can also be extended in future dev.
2. I set the api key value to point to system's default values in `configs/env.example`. Users may not need to reconfigure again.


The error raised by using gpt-5 with `temperature!=1`
```
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  File "/home/sijie/miniconda3/envs/repo/lib/python3.10/site-packages/openai/_base_client.py", line 919, in request
    return self._request(
  File "/home/sijie/miniconda3/envs/repo/lib/python3.10/site-packages/openai/_base_client.py", line 1023, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': "Unsupported value: 'temperature' does not support 0.1 with this model. Only the default (1) value is supported.", 'type': 'invalid_request_error', 'param': 'temperature', 'code': 'unsupported_value'}}


❌ Task execution error: Error code: 400 - {'error': {'message': "Unsupported value: 'temperature' does not support 0.1 with this model. Only the default (1) value is supported.", 'type': 'invalid_request_error', 'param': 'temperature', 'code': 'unsupported_value'}}
   💡 Please try to describe your task requirements in more detail
```